### PR TITLE
Add task management logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# DB connection details
+HOST=host
+DB_NAME=database_name
+DB_DIALECT=mysql
+DB_USER=database_user
+DB_PASSWORD=database_password
+DB_HOST=database_host
+DB_PORT=database_port
+
+# secret key for JWT
+SECRET_KEY=your_secret_key

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "http-status-codes": "^2.3.0",
+        "joi": "^17.13.3",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "mysql2": "^3.14.1",
@@ -25,6 +26,42 @@
         "@types/node": "^24.0.1",
         "typescript": "^5.8.3"
       }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -710,6 +747,19 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "mysql2": "^3.14.1",
+        "nodemon": "^3.1.10",
         "sequelize": "^6.37.7"
       },
       "devDependencies": {
@@ -213,6 +214,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -221,6 +235,12 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -249,6 +269,18 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -267,6 +299,28 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -312,6 +366,36 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -543,6 +627,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -576,6 +672,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -633,6 +743,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -643,6 +765,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -712,6 +843,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "license": "ISC"
+    },
     "node_modules/inflection": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
@@ -734,6 +871,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -933,6 +1112,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -1044,6 +1235,43 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1119,6 +1347,18 @@
       "integrity": "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==",
       "license": "MIT"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1131,6 +1371,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",
@@ -1169,6 +1415,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/retry-as-promised": {
@@ -1422,6 +1680,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -1440,6 +1710,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1454,6 +1748,15 @@
       "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
       "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg==",
       "license": "MIT"
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -1482,6 +1785,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "http-status-codes": "^2.3.0",
+    "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "mysql2": "^3.14.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "mysql2": "^3.14.1",
+    "nodemon": "^3.1.10",
     "sequelize": "^6.37.7"
   }
 }

--- a/src/controllers/task-management/taskController.ts
+++ b/src/controllers/task-management/taskController.ts
@@ -10,8 +10,11 @@ interface TaskData {
   end_date?: Date;
 }
 
-export const getAllTasks = async () => {
-  return await Task.findAll();
+export const getAllTasks = async (limit: number = 2, offset: number = 0) => {
+  return await Task.findAll({
+    limit,
+    offset,
+  });
 };
 
 export const getTaskById = async (id: number) => {

--- a/src/controllers/task-management/taskController.ts
+++ b/src/controllers/task-management/taskController.ts
@@ -1,0 +1,68 @@
+const db = require("../../models");
+const Task = db.task;
+
+interface TaskData {
+  title: string;
+  description?: string;
+  assigned_to: number;
+  status: "pending" | "active" | "completed" | "deferred" | "rejected";
+  start_date?: Date;
+  end_date?: Date;
+}
+
+export const getAllTasks = async () => {
+  return await Task.findAll();
+};
+
+export const getTaskById = async (id: number) => {
+  const task = await Task.findByPk(id);
+  if (!task) {
+    throw new Error("Task not found");
+  }
+  return task;
+};
+
+export const createTask = async (taskData: TaskData) => {
+  const taskWithDefaults = {
+    ...taskData,
+    status: taskData.status ?? "pending",
+  };
+
+  const task = await Task.create(taskWithDefaults);
+  if (!task) {
+    throw new Error("Failed to create task");
+  }
+  return task;
+};
+
+export const updateTask = async (id: number, taskData: Partial<TaskData>) => {
+  const [affectedCount] = await Task.update(taskData, {
+    where: { id },
+  });
+
+  if (affectedCount === 0) {
+    throw new Error("Task not found or no changes made");
+  }
+
+  return await getTaskById(id);
+};
+
+export const deleteTask = async (id: number) => {
+  const deletedCount = await Task.destroy({
+    where: { id },
+  });
+
+  if (deletedCount === 0) {
+    throw new Error("Task not found");
+  }
+
+  return { message: "Task deleted successfully" };
+};
+
+export default {
+  getAllTasks,
+  getTaskById,
+  createTask,
+  updateTask,
+  deleteTask,
+};

--- a/src/controllers/task-management/taskView.ts
+++ b/src/controllers/task-management/taskView.ts
@@ -1,0 +1,93 @@
+import { Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+import taskController from "./taskController";
+
+export const getAllTasksHandler = async (req: Request, res: Response) => {
+  try {
+    const tasks = await taskController.getAllTasks();
+    res.status(StatusCodes.OK).json(tasks);
+  } catch (err: any) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message,
+    });
+  }
+};
+
+export const getTaskHandler = async (req: Request, res: Response) => {
+  try {
+    const task = await taskController.getTaskById(Number(req.params.id));
+    res.status(StatusCodes.OK).json(task);
+  } catch (err: any) {
+    if (err.message === "Task not found") {
+      res.status(StatusCodes.NOT_FOUND).json({
+        message: err.message,
+      });
+    } else {
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: err.message,
+      });
+    }
+  }
+};
+
+export const createTaskHandler = async (req: Request, res: Response) => {
+  try {
+    const task = await taskController.createTask(req.body);
+    res.status(StatusCodes.CREATED).json({
+      message: "Task created successfully",
+      task,
+    });
+  } catch (err: any) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message,
+    });
+  }
+};
+
+export const updateTaskHandler = async (req: Request, res: Response) => {
+  try {
+    const task = await taskController.updateTask(
+      Number(req.params.id),
+      req.body
+    );
+    res.status(StatusCodes.OK).json({
+      message: "Task updated successfully",
+      task,
+    });
+  } catch (err: any) {
+    if (err.message === "Task not found or no changes made") {
+      res.status(StatusCodes.NOT_FOUND).json({
+        message: err.message,
+      });
+    } else {
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: err.message,
+      });
+    }
+  }
+};
+
+export const deleteTaskHandler = async (req: Request, res: Response) => {
+  try {
+    const result = await taskController.deleteTask(Number(req.params.id));
+    res.status(StatusCodes.OK).json(result);
+  } catch (err: any) {
+    if (err.message === "Task not found") {
+      res.status(StatusCodes.NOT_FOUND).json({
+        message: err.message,
+      });
+    } else {
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: err.message,
+      });
+    }
+  }
+};
+
+export default {
+  getAllTasksHandler,
+  getTaskHandler,
+  createTaskHandler,
+  updateTaskHandler,
+  deleteTaskHandler,
+};

--- a/src/controllers/task-management/taskView.ts
+++ b/src/controllers/task-management/taskView.ts
@@ -1,88 +1,115 @@
 import { Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import taskController from "./taskController";
+import {
+  TaskNotFoundError,
+  ValidationError,
+} from "../../errors/TaskNotFoundError";
+import {
+  taskCreateSchema,
+  taskUpdateSchema,
+  taskIdSchema,
+} from "../../errors/taskSchema";
 
 export const getAllTasksHandler = async (req: Request, res: Response) => {
   try {
     const tasks = await taskController.getAllTasks();
     res.status(StatusCodes.OK).json(tasks);
-  } catch (err: any) {
-    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: err.message,
-    });
+  } catch (err: unknown) {
+    handleError(res, err);
   }
 };
 
 export const getTaskHandler = async (req: Request, res: Response) => {
   try {
-    const task = await taskController.getTaskById(Number(req.params.id));
-    res.status(StatusCodes.OK).json(task);
-  } catch (err: any) {
-    if (err.message === "Task not found") {
-      res.status(StatusCodes.NOT_FOUND).json({
-        message: err.message,
-      });
-    } else {
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: err.message,
-      });
+    const { error, value } = taskIdSchema.validate(Number(req.params.id));
+    if (error) {
+      throw new ValidationError(error.details.map((d) => d.message).join(", "));
     }
+
+    const task = await taskController.getTaskById(value);
+    res.status(StatusCodes.OK).json(task);
+  } catch (err: unknown) {
+    handleError(res, err);
   }
 };
 
 export const createTaskHandler = async (req: Request, res: Response) => {
   try {
-    const task = await taskController.createTask(req.body);
+    const { error, value } = taskCreateSchema.validate(req.body);
+    if (error) {
+      throw new ValidationError(error.details.map((d) => d.message).join(", "));
+    }
+
+    const task = await taskController.createTask(value);
     res.status(StatusCodes.CREATED).json({
       message: "Task created successfully",
       task,
     });
-  } catch (err: any) {
-    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: err.message,
-    });
+  } catch (err: unknown) {
+    handleError(res, err);
   }
 };
 
 export const updateTaskHandler = async (req: Request, res: Response) => {
   try {
-    const task = await taskController.updateTask(
-      Number(req.params.id),
-      req.body
-    );
+    // Validate ID
+    const idValidation = taskIdSchema.validate(Number(req.params.id));
+    if (idValidation.error) {
+      throw new ValidationError(
+        idValidation.error.details.map((d) => d.message).join(", ")
+      );
+    }
+
+    // Validate body
+    const { error, value } = taskUpdateSchema.validate(req.body);
+    if (error) {
+      throw new ValidationError(error.details.map((d) => d.message).join(", "));
+    }
+
+    const task = await taskController.updateTask(idValidation.value, value);
     res.status(StatusCodes.OK).json({
       message: "Task updated successfully",
       task,
     });
-  } catch (err: any) {
-    if (err.message === "Task not found or no changes made") {
-      res.status(StatusCodes.NOT_FOUND).json({
-        message: err.message,
-      });
-    } else {
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: err.message,
-      });
-    }
+  } catch (err: unknown) {
+    handleError(res, err);
   }
 };
 
 export const deleteTaskHandler = async (req: Request, res: Response) => {
   try {
-    const result = await taskController.deleteTask(Number(req.params.id));
-    res.status(StatusCodes.OK).json(result);
-  } catch (err: any) {
-    if (err.message === "Task not found") {
-      res.status(StatusCodes.NOT_FOUND).json({
-        message: err.message,
-      });
-    } else {
-      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: err.message,
-      });
+    const { error, value } = taskIdSchema.validate(Number(req.params.id));
+    if (error) {
+      throw new ValidationError(error.details.map((d) => d.message).join(", "));
     }
+
+    const result = await taskController.deleteTask(value);
+    res.status(StatusCodes.OK).json(result);
+  } catch (err: unknown) {
+    handleError(res, err);
   }
 };
+
+function handleError(res: Response, err: unknown) {
+  if (err instanceof ValidationError) {
+    res.status(StatusCodes.BAD_REQUEST).json({
+      message: err.message,
+    });
+  } else if (err instanceof TaskNotFoundError) {
+    res.status(StatusCodes.NOT_FOUND).json({
+      message: err.message,
+    });
+  } else if (err instanceof Error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: err.message || "Internal server error",
+    });
+  } else {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: "An unknown error occurred",
+    });
+  }
+}
 
 export default {
   getAllTasksHandler,

--- a/src/errors/TaskNotFoundError.ts
+++ b/src/errors/TaskNotFoundError.ts
@@ -1,0 +1,13 @@
+export class TaskNotFoundError extends Error {
+  constructor(message = "Task not found") {
+    super(message);
+    this.name = "TaskNotFoundError";
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}

--- a/src/errors/taskSchema.ts
+++ b/src/errors/taskSchema.ts
@@ -1,0 +1,25 @@
+import Joi from "joi";
+
+export const taskCreateSchema = Joi.object({
+  title: Joi.string().required().min(3).max(100),
+  description: Joi.string().max(500).optional(),
+  assigned_to: Joi.number().integer().positive().required(),
+  status: Joi.string()
+    .valid("pending", "active", "completed", "deferred", "rejected")
+    .default("pending"),
+  start_date: Joi.date().optional(),
+  end_date: Joi.date().greater(Joi.ref("start_date")).optional(),
+}).options({ abortEarly: false });
+
+export const taskUpdateSchema = Joi.object({
+  title: Joi.string().min(3).max(100).optional(),
+  description: Joi.string().max(500).optional(),
+  assigned_to: Joi.number().integer().positive().optional(),
+  status: Joi.string()
+    .valid("pending", "active", "completed", "deferred", "rejected")
+    .optional(),
+  start_date: Joi.date().optional(),
+  end_date: Joi.date().optional(),
+}).options({ abortEarly: false });
+
+export const taskIdSchema = Joi.number().integer().positive().required();

--- a/src/middlewares/authJwt.ts
+++ b/src/middlewares/authJwt.ts
@@ -1,0 +1,123 @@
+import { NextFunction, Request, Response } from "express";
+import { StatusCodes } from "http-status-codes";
+const jwt = require("jsonwebtoken");
+const config = require("../config/auth.config");
+
+declare global {
+  namespace Express {
+    interface Request {
+      userId?: number;
+    }
+  }
+}
+
+type DecodedId = {
+  id: number;
+};
+
+const User = require("../models").user;
+
+export const getUserById = async (id: number) => {
+  return await User.findByPk(id);
+};
+
+export const checkUserRole = async (userId: number, roleName: string) => {
+  const user = await getUserById(userId);
+  if (!user) return false;
+  const roles = await user.getRoles();
+  return roles.some((role: any) => role.name === roleName);
+};
+
+export const checkUserRoles = async (userId: number, roleNames: string[]) => {
+  const user = await getUserById(userId);
+  if (!user) return false;
+  const roles = await user.getRoles();
+  return roles.some((role: any) => roleNames.includes(role.name));
+};
+
+const verifyToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const token = req.headers["x-access-token"] as string;
+
+  if (!token) {
+    res.status(StatusCodes.FORBIDDEN).send({
+      message:
+        "No token provided!, please provide token to access this resource!",
+    });
+  }
+
+  jwt.verify(token, config.secret, (err: Error, decoded: DecodedId) => {
+    if (err) {
+      return res.status(StatusCodes.UNAUTHORIZED).send({
+        message:
+          "Provided token is expired or invalid, please provide a valid token!",
+      });
+    }
+    req.userId = decoded.id;
+    next();
+  });
+};
+
+const isAdmin = async (req: any, res: Response, next: () => void) => {
+  try {
+    const hasRole = await checkUserRole(req.userId, "admin");
+    if (hasRole) {
+      return next();
+    }
+    res.status(StatusCodes.FORBIDDEN).send({
+      message: "Require Admin Role!",
+    });
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+      message: "Internal server error!",
+    });
+  }
+};
+
+const isModerator = async (req: any, res: Response, next: () => void) => {
+  try {
+    const hasRole = await checkUserRole(req.userId, "moderator");
+    if (hasRole) {
+      return next();
+    }
+    res.status(StatusCodes.FORBIDDEN).send({
+      message: "Require Moderator Role!",
+    });
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+      message: "Internal server error!",
+    });
+  }
+};
+
+const isModeratorOrAdmin = async (
+  req: any,
+  res: Response,
+  next: () => void
+) => {
+  try {
+    const hasRole = await checkUserRoles(req.userId, ["moderator", "admin"]);
+    if (hasRole) {
+      return next();
+    }
+    res.status(StatusCodes.FORBIDDEN).send({
+      message: "Require Moderator or Admin Role!",
+    });
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).send({
+      message: "Internal server error!",
+    });
+  }
+};
+
+const authJwt = {
+  verifyToken,
+  isAdmin,
+  isModerator,
+  isModeratorOrAdmin,
+};
+
+export default authJwt;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 const router = express.Router();
 import authController from "../controllers/authentication/authView";
+import taskView from "../controllers/task-management/taskView";
 import verifySignUp from "../middlewares/verifySignUp";
 
 router.post("/auth/login", authController.signin);
@@ -10,6 +11,13 @@ router.post(
   [verifySignUp.checkDuplicateUsernameOrEmail, verifySignUp.checkRolesExisted],
   authController.createUser
 );
+
+router.get("/tasks", taskView.getAllTasksHandler);
+router.get("/tasks/:id", taskView.getTaskHandler);
+router.post("/tasks", taskView.createTaskHandler);
+router.put("/tasks/:id", taskView.updateTaskHandler);
+router.delete("/tasks/:id", taskView.deleteTaskHandler);
+
 module.exports = router;
 
 export = router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ const router = express.Router();
 import authController from "../controllers/authentication/authView";
 import taskView from "../controllers/task-management/taskView";
 import verifySignUp from "../middlewares/verifySignUp";
+import authJwt from "../middlewares/authJwt";
 
 router.post("/auth/login", authController.signin);
 
@@ -12,11 +13,11 @@ router.post(
   authController.createUser
 );
 
-router.get("/tasks", taskView.getAllTasksHandler);
-router.get("/tasks/:id", taskView.getTaskHandler);
-router.post("/tasks", taskView.createTaskHandler);
-router.put("/tasks/:id", taskView.updateTaskHandler);
-router.delete("/tasks/:id", taskView.deleteTaskHandler);
+router.get("/tasks", [authJwt.verifyToken], taskView.getAllTasksHandler);
+router.get("/tasks/:id", [authJwt.verifyToken], taskView.getTaskHandler);
+router.post("/tasks", [authJwt.verifyToken], taskView.createTaskHandler);
+router.put("/tasks/:id", [authJwt.verifyToken], taskView.updateTaskHandler);
+router.delete("/tasks/:id", [authJwt.verifyToken], taskView.deleteTaskHandler);
 
 module.exports = router;
 


### PR DESCRIPTION
On this PR I am adding task management logic

## Summary by Sourcery

Introduce task management logic by adding full CRUD support for tasks via new Express routes, view handlers, and controller methods interacting with the Task model.

New Features:
- Expose CRUD REST API endpoints for tasks at /tasks
- Add taskView handlers to handle HTTP requests and responses for task operations
- Implement taskController methods to perform CRUD operations using the Task Sequelize model